### PR TITLE
v1.7.1 release

### DIFF
--- a/RSS-Button-MacOS/SettingsManager.swift
+++ b/RSS-Button-MacOS/SettingsManager.swift
@@ -19,6 +19,7 @@ class SettingsManager {
     let badgeButtonKey = "badgeButtonState"
     let unsupportedHandlers = [
         "com.apple.news",              // Apple News
+        "com.apple.mail",              // Apple Mail
         "com.newsbar-app",             // Newsbar
         "org.mozilla.thunderbird",     // Mozilla Thunderbird
         "com.reederapp.rkit2.mac",     // Reeder v3

--- a/RSS-Button-MacOS/ViewController.swift
+++ b/RSS-Button-MacOS/ViewController.swift
@@ -159,27 +159,18 @@ class ViewController: NSViewController, NSWindowDelegate, NSTextFieldDelegate {
         
         self.readerPopUpButton.menu = readerMenu
         
-        // Set the default feed handler if on first run unless apple news
-        if !self.settingsManager.isFeedHandlerSet() {
-            if defaultFeedHandler != nil && defaultFeedHandler! as String != "com.apple.news",
-                let feedHandlerToSet = self.feedHandlers.first(where: {$0.appId == defaultFeedHandler! as String}) {
-                
-                if self.settingsManager.isSupportedFeedHandler() {
-                    self.readerPopUpButton.selectItem(withTitle: feedHandlerToSet.title)
-                    self.settingsManager.setFeedHandler(feedHandlerToSet)
-                }
-            } else {
-                if self.feedHandlers.filter({$0.type == FeedHandlerType.app}).count > 0 {
-                    self.settingsManager.noFeedHandlerConfiguredAlert()
-                } else {
-                    self.settingsManager.noFeedHandlersAlert()
-                }
-            }
-        } else {
+        // Set the feed handler if configured or alert
+        if self.settingsManager.isFeedHandlerSet() {
             if (self.feedHandlers.first(where: {$0.title == feedHandler.title}) != nil) {
                 self.readerPopUpButton.selectItem(withTitle: feedHandler.title)
             } else {
                 self.settingsManager.noFeedHandlerConfiguredAlert()
+            }
+        } else {
+            if self.feedHandlers.filter({$0.type == FeedHandlerType.app}).count > 0 {
+                self.settingsManager.noFeedHandlerConfiguredAlert()
+            } else {
+                self.settingsManager.noFeedHandlersAlert()
             }
         }
     }

--- a/RSS-Button-for-Safari.xcodeproj/project.pbxproj
+++ b/RSS-Button-for-Safari.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = YE2H3T9GV5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "RSS-Button-MacOS/Info.plist";
@@ -595,7 +595,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.7.1;
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitpiston.RSSButton4Safari;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -614,7 +614,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = YE2H3T9GV5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "RSS-Button-MacOS/Info.plist";
@@ -623,7 +623,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitpiston.RSSButton4Safari;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -717,7 +717,7 @@
 				CODE_SIGN_ENTITLEMENTS = "RSS-Button-Safari-Extension/RSS_Button.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = YE2H3T9GV5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "RSS-Button-Safari-Extension/Info.plist";
@@ -727,7 +727,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.7.1;
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitpiston.RSSButton4Safari.SafariExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -745,7 +745,7 @@
 				CODE_SIGN_ENTITLEMENTS = "RSS-Button-Safari-Extension/RSS_Button.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = YE2H3T9GV5;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "RSS-Button-Safari-Extension/Info.plist";
@@ -755,7 +755,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitpiston.RSSButton4Safari.SafariExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
- Blacklists Apple Mail as old user profiles from when Apple Mail supported RSS could be set as the default feed handler in launch services
- Removes setting the default handler from launch services at first run. User interaction is now required to select their news reader.